### PR TITLE
fix: update Android APK download link to main whitenoise repo

### DIFF
--- a/src/routes/download/+page.svelte
+++ b/src/routes/download/+page.svelte
@@ -14,7 +14,7 @@ const downloadSchema = JSON.stringify({
         "price": "0",
         "priceCurrency": "USD"
     },
-    "downloadUrl": "https://github.com/marmot-protocol/whitenoise-archive/releases/latest",
+    "downloadUrl": "https://github.com/marmot-protocol/whitenoise/releases/latest",
     "softwareVersion": "beta",
     "isAccessibleForFree": true
 });
@@ -74,7 +74,7 @@ const downloadSchema = JSON.stringify({
         <!-- Android APK -->
         <div class="flex flex-col items-center text-center">
             <a
-                href="https://github.com/marmot-protocol/whitenoise-archive/releases/latest"
+                href="https://github.com/marmot-protocol/whitenoise/releases/latest"
                 target="_blank"
                 class="bg-glitch-950 hover:bg-glitch-800 text-glitch-50 px-8 py-4 text-xl font-medium transition-colors duration-200 flex flex-row gap-3 items-center justify-center w-full"
             >


### PR DESCRIPTION
## Summary
- Updated Android APK download link from `whitenoise-archive` to main `whitenoise` repository
- Updated schema.org downloadUrl metadata to match

## Test plan
- [ ] Verify link on /download page points to https://github.com/marmot-protocol/whitenoise/releases/latest
- [ ] Confirm APK is available at the new location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated download links to direct to the correct repository location for accessing releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->